### PR TITLE
⬆️ Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,7 @@ updates:
       default-days: 7
     commit-message:
       prefix: ⬆
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add Dependabot groups to ungrouped update entries.
- Keep existing schedules, cooldowns, labels, and commit message settings unchanged.

## AI Disclaimer
Codex GPT 5.5, reviewed by hand.
